### PR TITLE
Make separate environment vars for SUBNET1 and SUBNET2

### DIFF
--- a/static/cfn/bootstrap.cfn.yaml
+++ b/static/cfn/bootstrap.cfn.yaml
@@ -182,6 +182,7 @@ Outputs:
         Value: !Sub |
              #!/bin/bash
              export BUCKET_NAME="${S3Bucket}"
-             export SUBNETS="${PublicSubnet1},${PublicSubnet2}"
+             export SUBNET1="${PublicSubnet1}"
+             export SUBNET2="${PublicSubnet2}"
              export SECURITY_GROUP="${VPC.DefaultSecurityGroup}"
              export ROLE_ARN="${RoboMakerDeploymentRole.Arn}"


### PR DESCRIPTION
Latest workshop code seems to expect separate environment variables for each subnet; this will need testing but I think update is correct.

The only other hiccup I saw was that the Stack name is used in naming S3 buckets, which can cause a naming error (in my case due to using uppercase in the Stack name).

Thanks!