### PR TITLE
added action to copy to S3 bucket

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: CopyToS3
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+    - name: Copy Templates
+      run: aws s3 sync static/cfn s3://assets.robomakerworkshops.com/cfn  --delete

--- a/.github/workflows/main.yml~
+++ b/.github/workflows/main.yml~
@@ -1,0 +1,15 @@
+name: CopyToS3
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+    - name: Copy Templates
+      run: aws s3 sync static/cfn s3://assets.robomakerworkshops.com/cfn/bootstrap.rover.cfn.yaml  --delete


### PR DESCRIPTION
If you go to secrets and add your AWS creds per [this article](https://blog.kylegalbraith.com/2019/12/09/deploying-your-static-websites-to-aws-in-style-using-github-actions/)  and accept this PR then any time you commit to master your CF templates will be copied to S3, ensuring that your demos get up to date CF templates.